### PR TITLE
Remove unused is_max

### DIFF
--- a/scheduled_payments/payment_dialog.py
+++ b/scheduled_payments/payment_dialog.py
@@ -27,7 +27,6 @@ class PaymentDialog(QDialog, MessageBoxMixin):
         # WARNING: Copying some attributes so PayToEdit() will work.
         self.main_window = window
         self.contacts = self.main_window.contacts
-        self.is_max = self.main_window.is_max # Unused, as we do not use max.
         self.completions = self.main_window.completions
 
         self.count_labels = [


### PR DESCRIPTION
is_max was removed in this Electron Cash commit

https://github.com/Electron-Cash/Electron-Cash/commit/f3c404d203727a93b9baa6a2eef076b2579fc8b0

As it seems to be unused this patch just removes it

See https://github.com/Electron-Cash/Electron-Cash/issues/1301